### PR TITLE
Fix Parse error with @-webkit-keyframes at rule

### DIFF
--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -127,7 +127,14 @@ let at_rule = [%sedlex.regexp? "@", ident]
 
 let at_rule_without_body = [%sedlex.regexp? "@", ("charset" | "import" | "namespace")]
 
-let nested_at_rule = [%sedlex.regexp? "@", ("document" | "keyframes" | "media" | "supports" | "scope" | "-webkit-keyframes" )]
+(*Complete list from https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule*)
+let nested_at_rule =
+  [%sedlex.regexp?
+    ( "@",
+      ( "charset" | "import" | "namespace" | "media" | "supports" | "document"
+      | "page" | "font-face" | "-webkit-keyframes" | "keyframes"
+      | "-ms-viewport" | "-o-viewport" | "viewport" | "counter-style"
+      | "font-feature-values" | "scope" ) )]
 
 let _a = [%sedlex.regexp? 'A' | 'a']
 let _b = [%sedlex.regexp? 'B' | 'b']

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -127,7 +127,7 @@ let at_rule = [%sedlex.regexp? "@", ident]
 
 let at_rule_without_body = [%sedlex.regexp? "@", ("charset" | "import" | "namespace")]
 
-let nested_at_rule = [%sedlex.regexp? "@", ("document" | "keyframes" | "media" | "supports" | "scope")]
+let nested_at_rule = [%sedlex.regexp? "@", ("document" | "keyframes" | "media" | "supports" | "scope" | "-webkit-keyframes" )]
 
 let _a = [%sedlex.regexp? 'A' | 'a']
 let _b = [%sedlex.regexp? 'B' | 'b']


### PR DESCRIPTION
@astrada A user for one of my projects [reported the parser throwing an error](https://github.com/dylanirlbeck/tailwind-ppx/issues/89) for the following at rule:

```css
@-webkit-keyframes hide {
  from {
    opacity: 0.8;
    visibility: visible;
  }

  to {
    opacity: 0;
    height: 0;
    visibility: hidden;
  }
}
```

It seems like the change to support this rule would be trivial --- just update the at rule regexp, so I went ahead and made the change.

I edited this file from GH, so let me know if you want me to pull this down and format it. You're also more than welcome to close this PR and implement the changes yourself (and perhaps include a test?). Thanks in advance!